### PR TITLE
fix PCM metadata

### DIFF
--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -8,16 +8,16 @@
     "author": {
         "name": "ebastler and MarvFPV",
         "contact": {
-            "discord": "https://discord.gg/UEhmQbQw",
+            "discord": "https://discord.gg/UEhmQbQw"
         }
     },
     "maintainer": {
         "name": "ebastler and MarvFPV",
         "contact": {
-            "discord": "https://discord.gg/UEhmQbQw",
+            "discord": "https://discord.gg/UEhmQbQw"
         }
     },
-    "license": "CERN-OHL-P-2.0",
+    "license": "CERN-OHL",
     "resources": {
         "homepage": "https://github.com/ebastler/marbastlib"
     },


### PR DESCRIPTION
* remove extra comma from JSON so it is valid
* change invalid license CERN-OHL-P-2.0 to valid license CERN-OHL (errors 
in PCM otherwise) [valid license names](https://dev-docs.kicad.org/en/addons/)
